### PR TITLE
fix issue with rowwise applied imputation on dataframes

### DIFF
--- a/R/apply_imputation.R
+++ b/R/apply_imputation.R
@@ -119,7 +119,7 @@ apply_imputation <- function(ds, FUN = mean, type = "columnwise", ...) {
           " all values are NA; the row cannot be imputed"
         )
       } else if (any(M_i)) {
-        ds[i, M_i] <- FUN(ds[i, !M_i, drop = TRUE], ...)
+        ds[i, M_i] <- FUN(unlist(ds[i, !M_i, drop = TRUE]), ...)
       }
     }
   } else if (type == "total") { # total -------------------


### PR DESCRIPTION
Fixes an issue with row-wise applied imputation on dataframes.

In the current code, the subsetting call:

```
ds[i, M_i] <- FUN(ds[i, !M_i, drop = TRUE], ...)
```

will work for matrices, but for dataframes, the result is a list, which throws off `mean()`, etc.

A simple work-around is to call `unlist()`, which works for both matrices and dataframes.

(Converting the row to a row matrix via `as.matrix()` would also work..)

**To reproduce the issue:**

```
x <- structure(list(V1 = c(11.08, 25.23, 26.67, 12.86, 21.94, 27.13
), V2 = c(11.21, 29.79, 26.83, 13.8, 26.42, 26.67), V3 = c(10.87,
25.87, 22.5, 14.42, 21.27, 24.68), V4 = c(11.29, 28, 17.23, 15.94,
24.86, 24.62), V5 = c(12.34, 24.99, 22.68, 12.36, 28.59, 27.51
), V6 = c(0.28, 86.53, NA, 0, 203.22, 37.96)), row.names = c("a",
"b", "c", "d", "e", "f"), class = "data.frame")

missMethods::impute_mean(x, type='rowwise')
     V1    V2    V3    V4    V5     V6
a 11.08 11.21 10.87 11.29 12.34   0.28
b 25.23 29.79 25.87 28.00 24.99  86.53
c 26.67 26.83 22.50 17.23 22.68     NA
d 12.86 13.80 14.42 15.94 12.36   0.00
e 21.94 26.42 21.27 24.86 28.59 203.22
f 27.13 26.67 24.68 24.62 27.51  37.96
Warning message:
In mean.default(ds[i, !M_i, drop = TRUE], ...) :
  argument is not numeric or logical: returning NA
Calls: <Anonymous> -> apply_imputation -> FUN -> mean.default
```
